### PR TITLE
feat: implementar GET /users/ para listar todos los usuarios (admin) #100

### DIFF
--- a/Backend/app/database.py
+++ b/Backend/app/database.py
@@ -108,6 +108,46 @@ def get_user_by_id(user_id: str) -> UserDb | None:
     return None
 
 
+def get_all_users_db(skip: int = 0, limit: int = 20, search: str = None) -> list:
+    with mariadb.connect(**db_config) as conn:
+        with conn.cursor() as cursor:
+            sql = """
+                SELECT u.id, u.name, u.email, u.password, u.role,
+                       u.location, u.description, u.profile_image,
+                       s.id AS shelter_id,
+                       l.name AS location_name
+                FROM USERS u
+                LEFT JOIN SHELTER s ON s.admin = u.id
+                LEFT JOIN LOCALITY l ON l.id = u.location
+            """
+            params = []
+            if search:
+                sql += " WHERE u.name LIKE ? OR u.email LIKE ?"
+                params = [f"%{search}%", f"%{search}%"]
+            
+            sql += " LIMIT ? OFFSET ?"
+            params += [limit, skip]
+            
+            cursor.execute(sql, tuple(params))
+            results = cursor.fetchall()
+            
+            users = []
+            for result in results:
+                users.append(UserDb(
+                    id=result[0],
+                    name=result[1],
+                    email=result[2],
+                    password=result[3],
+                    role=result[4],
+                    location=result[5],
+                    description=result[6],
+                    profile_image=result[7],
+                    shelter_id=result[8],
+                    location_name=result[9]
+                ))
+            return users
+
+
 def update_user_db(user_id: int, data: dict) -> bool:
     with mariadb.connect(**db_config) as conn:
         with conn.cursor() as cursor:

--- a/Backend/app/models/users.py
+++ b/Backend/app/models/users.py
@@ -30,6 +30,7 @@ class UserOut(UserBase):
 class UserDb(UserIn):
     id: str
     shelter_id: Optional[str] = None
+    location_name: Optional[str] = None
 
 #Class Login: Para poder facilitar el inicio de sesion
 class UserLogin(UserBase):

--- a/Backend/app/routers/users.py
+++ b/Backend/app/routers/users.py
@@ -7,7 +7,17 @@ from typing import Optional
 from pydantic import BaseModel
 from app.models.users import UserIn, UserOut, UserUpdate, UserDb, EmailUpdate, PasswordUpdate
 from app.models.shelters import ShelterRegistrationData
-from app.database import insert_user, insert_user_with_shelter, get_user_by_email, get_user_by_id, update_user_db, update_user_email, update_user_password, update_user_photo_db
+from app.database import (
+    insert_user, 
+    insert_user_with_shelter, 
+    get_user_by_email, 
+    get_user_by_id, 
+    update_user_db, 
+    update_user_email, 
+    update_user_password, 
+    update_user_photo_db,
+    get_all_users_db
+)
 import shutil
 from app.auth.auth import (
     get_hash_password, 
@@ -115,6 +125,25 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends()):
 @router.get("/me", response_model=UserOut)
 async def get_profile(current_user: UserOut = Depends(get_current_user)):
     return current_user
+
+
+@router.get("/", response_model=list[UserOut])
+async def list_users(
+    skip: int = 0,
+    limit: int = 20,
+    search: Optional[str] = None,
+    current_user: UserDb = Depends(get_current_user)
+):
+    # 1. Solo el admin puede listar usuarios
+    if current_user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Acceso denegado"
+        )
+    
+    # 2. Obtener lista desde la DB
+    users = get_all_users_db(skip=skip, limit=limit, search=search)
+    return users
 
 
 @router.get("/{user_id}", response_model=UserOut)


### PR DESCRIPTION
#100 : Se ha implementado el endpoint para que los administradores puedan consultar la lista completa de usuarios registrados.

Endpoint: GET /users/ (restringido a admin).
Funcionalidades:
Compatible con paginación (skip y limit).
Soporte para búsqueda por nombre o email (search).
Información detallada incluyendo location_name mediante un JOIN con la tabla LOCALITY.
Cambios técnicos:
Nueva función get_all_users_db en la base de datos.
Actualización del modelo UserDb para soportar location_name